### PR TITLE
Fix #13 add fixture seed data for ResourceCategory model

### DIFF
--- a/devresources/fixtures/ResourceCategory.yaml
+++ b/devresources/fixtures/ResourceCategory.yaml
@@ -1,0 +1,27 @@
+---
+- model: core.ResourceCategory
+  pk: 1
+  fields:
+    title: python
+    slug: python
+    added_by: 1
+    added_on: "2021-01-16T17:41:28+00:00"
+    updated_on: "2021-01-16T17:41:28+00:00"
+
+- model: core.ResourceCategory
+  pk: 2
+  fields:
+    title: django
+    slug: django
+    added_by: 1
+    added_on: "2021-01-16T17:41:28+00:00"
+    updated_on: "2021-01-16T17:41:28+00:00"
+
+- model: core.ResourceCategory
+  pk: 3
+  fields:
+    title: c++
+    slug: c++
+    added_by: 1
+    added_on: "2021-01-16T17:41:28+00:00"
+    updated_on: "2021-01-16T17:41:28+00:00"


### PR DESCRIPTION
Fix #13 add fixture seed data for ResourceCategory model

May be ran with
```
python manage.py loaddata devresources/fixtures/ResourceCategory.yaml
```